### PR TITLE
[Update]ユーザー側キーワード検索追加

### DIFF
--- a/app/assets/stylesheets/public/searches.scss
+++ b/app/assets/stylesheets/public/searches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/searches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -1,0 +1,18 @@
+class Public::SearchesController < ApplicationController
+
+  def search
+    @posts = Post.search(params[:keyword])
+  end
+
+#   def search
+# 		@model = params[:model]
+# 		@content = params[:content]
+# 		@method = params[:method]
+# 		if @model == 'user'
+# 			@records = User.search_for(@content, @method)
+# 		else
+# 			@records = Book.search_for(@content, @method)
+# 		end
+# 	end
+
+end

--- a/app/helpers/public/searches_helper.rb
+++ b/app/helpers/public/searches_helper.rb
@@ -1,0 +1,2 @@
+module Public::SearchesHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,14 @@ class Post < ApplicationRecord
   has_many :bookmark, dependent: :destroy
   has_many :comment, dependent: :destroy
 
+  # 投稿の仕事内容カラムを範囲とし、キーワード検索をかけられる
+  # キーワードが入力されない場合は投稿一覧が表示される
+  def self.search(search)
+    if search != ""
+      Post.where(['answer_what LIKE(?)', "%#{search}%"])
+    else
+      Post.all
+    end
+  end
+
 end

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row mb-5">
   <div class="col-md-4">
-    <%# render 検索窓  %>
+    <% render 'public/searches/search' %>
   </div>
 
   <div class="col-md-8">

--- a/app/views/public/searches/_search.html.erb
+++ b/app/views/public/searches/_search.html.erb
@@ -1,0 +1,7 @@
+<div class="border border-secondary" style="background-color: #66cdaa;" >
+  <p>仕事内容から検索ができます</p>
+  <%= form_with url: search_path, local: true, method: :get do |f| %>
+    <%= f.text_field :keyword, placeholder: "(例)事務、営業、接客など" %>
+    <%= f.submit '検索' %>
+  <% end %>
+</div>

--- a/app/views/public/searches/search.html.erb
+++ b/app/views/public/searches/search.html.erb
@@ -1,0 +1,25 @@
+<div class="row mb-5">
+  <div class="col-md-4">
+    <% render 'public/searches/search' %>
+  </div>
+
+  <div class="col-md-8">
+    <% if @posts == [] %>
+
+      <h3>お探しのキーワードでは投稿が見つかりませんでした。</h3>
+
+    <% else %>
+
+      <h3>"<%= @keyword %>"による検索結果</h3>
+      <% @posts.each do |post| %>
+
+        <p><%= post.industry_id %></p>
+        <p><%= post.answer_what %></p>
+        <%= link_to "この体験談を見る >", post_path(post.id) %>
+
+      <% end %>
+
+    <% end %>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
 
   end
 
+  # searches
+  get '/search', to: 'searches#search'
 
   end
 

--- a/test/controllers/public/searches_controller_test.rb
+++ b/test/controllers/public/searches_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::SearchesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
ユーザー側キーワード検索機能追加。検索範囲は仕事内容(カラム名：answer_what)に限定。
キーワード検索に投稿が1件も引っ掛からない場合は"お探しのキーワードでは体験談は見つかりませんでした。"と画面に表示される。
キーワードを入力せずに検索を掛けた場合は全ての投稿が表示される仕様とした。